### PR TITLE
sna: fix missing include of <sys/select.h>

### DIFF
--- a/src/sna/sna.h
+++ b/src/sna/sna.h
@@ -38,6 +38,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define _SNA_H_
 
 #include <stdint.h>
+#include <sys/select.h>
 
 #include <xorg-server.h>
 #include <xf86str.h>


### PR DESCRIPTION
Include <sys/select.h> to provide timer_tv. Fixes the missing definition
when sna is enabled and udev is disabled in configure.

Fixes: #10
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
