### PR TITLE
drop fd_move_cloexec()

### DIFF
--- a/src/backlight.c
+++ b/src/backlight.c
@@ -326,7 +326,7 @@ int backlight_exists(const char *iface)
 
 static int __backlight_init(struct backlight *b, char *iface, int fd)
 {
-	b->fd = fd_move_cloexec(fd_set_nonblock(fd));
+	b->fd = fd_set_nonblock(fd);
 	b->iface = iface;
 	return 1;
 }

--- a/src/fd.c
+++ b/src/fd.c
@@ -37,28 +37,6 @@
 
 #include "fd.h"
 
-int fd_move_cloexec(int fd)
-{
-	int newfd;
-
-	newfd = fcntl(fd,
-#ifdef F_DUPFD_CLOEXEC
-		      F_DUPFD_CLOEXEC,
-#else
-		      F_DUPFD,
-#endif
-		      MAXCLIENTS);
-	if (newfd < 0)
-		return fd;
-
-#ifndef F_DUPFD_CLOEXEC
-	newfd = fd_set_cloexec(newfd);
-#endif
-
-	close(fd);
-	return newfd;
-}
-
 int fd_set_cloexec(int fd)
 {
 	int flags;


### PR DESCRIPTION
There's really no need to duplicate fd to a trivial sysfs file, neither any need to explicitly mark it as close-on-exec. There's no locking whatsoever involved, even parallel writes are fully supported for sysfs attribute files.

And the way it was done was really weird and fragile: it just brutely overwrote fd # MAXCLIENTS. The MAXCLIENTS define is internal to the Xserver, outside of individual driver's concern, and drivers really shouldn't directly mess with the fd table that way - they have no way to make sure it's really done right.

Therefore, just drop this all and leave the fd as it is.