### PR TITLE
sna: sna_damage: fix missing include of extinit.h

### DIFF
--- a/src/sna/sna_damage.c
+++ b/src/sna/sna_damage.c
@@ -28,6 +28,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+#include <extinit.h>
+
 #include "sna.h"
 #include "sna_damage.h"
 

--- a/src/sna/sna_video.c
+++ b/src/sna/sna_video.c
@@ -52,6 +52,9 @@
 
 #include <sys/mman.h>
 
+#include <xorg-server.h>
+#include <extinit.h>
+
 #include "sna.h"
 #include "sna_reg.h"
 #include "sna_video.h"


### PR DESCRIPTION
> sna_video.c: In function 'sna_video_init':
> sna_video.c:956:13: error: 'noXvExtension' undeclared (first use in this function); did you mean 'XvExtension'?
>   956 |         if (noXvExtension)
>       |             ^~~~~~~~~~~~~
>       |             XvExtension