### PR TITLE
sna: drop compile-time check for GLYPHPADBYTES == 4

### DIFF
--- a/src/sna/fb/fb.h
+++ b/src/sna/fb/fb.h
@@ -57,10 +57,6 @@
 #error "IMAGE_BYTE_ORDER must be LSBFirst"
 #endif
 
-#if GLYPHPADBYTES != 4
-#error "GLYPHPADBYTES must be 4"
-#endif
-
 #if FB_SHIFT != 5
 #error "FB_SHIFT ala LOG2_BITMAP_PAD must be 5"
 #endif


### PR DESCRIPTION
It's always defined to 4, so extra check necessary.

See: xserver commit https://github.com/X11Libre/xserver/commit/17c3347f14822b9f7da4253c71f6ed51be2b38d1.