### PR TITLE
bump minimal xorg version to 1.18

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -369,7 +369,7 @@ AC_ARG_ENABLE(ums-only,
               [ONLY_UMS="$enableval"],
               [ONLY_UMS="no"])
 
-required_xorg_server_version=1.6
+required_xorg_server_version=1.18
 required_pixman_version=0.16
 
 PKG_CHECK_EXISTS([pixman-1 >= 0.24.0],


### PR DESCRIPTION
1.18 was released a decade ago, so it seems reasonable stop supporting older ones.