### PR TITLE
sna: declare the macros from micoord.h on our own

### DIFF
--- a/src/sna/fb/fb.h
+++ b/src/sna/fb/fb.h
@@ -21,10 +21,13 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef FB_H
-#define FB_H
+#ifndef __XF86_VIDEO_INTEL_SNA_FB_H
+#define __XF86_VIDEO_INTEL_SNA_FB_H
 
 #include <xorg-server.h>
+
+#include <X11/Xarch.h>          /* for X_LITTLE_ENDIAN/X_BIG_ENDIAN */
+
 #include <servermd.h>
 #include <gcstruct.h>
 #include <colormap.h>
@@ -38,6 +41,26 @@
 
 #include "../../compat-api.h"
 #include "../debug.h"
+
+/* Macros which handle a coordinate in a single register */
+
+#ifndef GetHighWord
+
+#define GetHighWord(x) (((int) (x)) >> 16)
+
+#if X_BYTE_ORDER == X_LITTLE_ENDIAN
+# define coordToInt(x,y) (((y) << 16) | ((x) & 0xffff))
+# define intToX(i)       ((int) ((short) (i)))
+# define intToY(i)       (GetHighWord(i))
+#elif X_BYTE_ORDER == X_BIG_ENDIAN
+# define coordToInt(x,y) (((x) << 16) | ((y) & 0xffff))
+# define intToX(i)       (GetHighWord(i))
+# define intToY(i)       ((int) ((short) i))
+#else
+# error "Too weird to live."
+#endif
+
+#endif
 
 #define WRITE(ptr, val) (*(ptr) = (val))
 #define READ(ptr) (*(ptr))
@@ -561,4 +584,4 @@ fbTile(FbBits *dst, FbStride dstStride, int dstX, int width, int height,
 
 extern FbBits fbReplicatePixel(Pixel p, int bpp);
 
-#endif  /* FB_H */
+#endif  /* __XF86_VIDEO_INTEL_SNA_FB_H */

--- a/src/sna/fb/fbline.c
+++ b/src/sna/fb/fbline.c
@@ -23,7 +23,6 @@
 
 #include "fb.h"
 #include <mi.h>
-#include <micoord.h>
 #include <miline.h>
 #include <scrnintstr.h>
 

--- a/src/sna/fb/fbpoint.c
+++ b/src/sna/fb/fbpoint.c
@@ -22,7 +22,6 @@
  */
 
 #include "fb.h"
-#include <micoord.h>
 
 #define DOTS	    fbDots8
 #define DOTS__SIMPLE fbDots8__simple


### PR DESCRIPTION
The <micoord.h> file is deprecated and this is the only driver actually using it, so define them on our own.