### PR TITLE
drop unused _MSC_VER check

### DIFF
--- a/src/sna/sna_display.c
+++ b/src/sna/sna_display.c
@@ -47,9 +47,6 @@
 #define alloca __builtin_alloca
 #elif defined _AIX
 #define alloca __alloca
-#elif defined _MSC_VER
-#include <malloc.h>
-#define alloca _alloca
 #else
 void *alloca(size_t);
 #endif


### PR DESCRIPTION
Probably a copy+paste bug: this driver doesn't work at all under Windows.