### PR TITLE
drop obsolete check for HAS_DIXREGISTERPRIVATEKEY

### DIFF
--- a/src/sna/sna_driver.c
+++ b/src/sna/sna_driver.c
@@ -843,11 +843,7 @@ sna_handle_uevents(int fd, void *closure)
 
 static bool has_randr(void)
 {
-#if HAS_DIXREGISTERPRIVATEKEY
 	return dixPrivateKeyRegistered(rrPrivKey);
-#else
-	return *rrPrivKey;
-#endif
 }
 
 static void
@@ -1039,7 +1035,6 @@ static Bool sna_late_close_screen(CLOSE_SCREEN_ARGS_DECL)
 static Bool
 sna_register_all_privates(void)
 {
-#if HAS_DIXREGISTERPRIVATEKEY
 	if (!dixRegisterPrivateKey(&sna_pixmap_key, PRIVATE_PIXMAP,
 				   3*sizeof(void *)))
 		return FALSE;
@@ -1059,22 +1054,6 @@ sna_register_all_privates(void)
 	if (!dixRegisterPrivateKey(&sna_client_key, PRIVATE_CLIENT,
 				   sizeof(struct sna_client)))
 		return FALSE;
-#else
-	if (!dixRequestPrivate(&sna_pixmap_key, 3*sizeof(void *)))
-		return FALSE;
-
-	if (!dixRequestPrivate(&sna_gc_key, sizeof(FbGCPrivate)))
-		return FALSE;
-
-	if (!dixRequestPrivate(&sna_glyph_key, sizeof(struct sna_glyph)))
-		return FALSE;
-
-	if (!dixRequestPrivate(&sna_window_key, 3*sizeof(void *)))
-		return FALSE;
-
-	if (!dixRequestPrivate(&sna_client_key, sizeof(struct sna_client)))
-		return FALSE;
-#endif
 
 	return TRUE;
 }

--- a/src/uxa/intel_dri.c
+++ b/src/uxa/intel_dri.c
@@ -660,11 +660,7 @@ i830_dri2_register_frame_event_resource_types(void)
 static XID
 get_client_id(ClientPtr client)
 {
-#if HAS_DIXREGISTERPRIVATEKEY
 	XID *ptr = dixGetPrivateAddr(&client->devPrivates, &i830_client_key);
-#else
-	XID *ptr = dixLookupPrivate(&client->devPrivates, &i830_client_key);
-#endif
 	if (*ptr == 0)
 		*ptr = FakeClientID(client->index);
 	return *ptr;
@@ -1569,14 +1565,8 @@ Bool I830DRI2ScreenInit(ScreenPtr screen)
 		return FALSE;
 	}
 
-#if HAS_DIXREGISTERPRIVATEKEY
 	if (!dixRegisterPrivateKey(&i830_client_key, PRIVATE_CLIENT, sizeof(XID)))
 		return FALSE;
-#else
-	if (!dixRequestPrivate(&i830_client_key, sizeof(XID)))
-		return FALSE;
-#endif
-
 
 #if DRI2INFOREC_VERSION >= 4
 	if (serverGeneration != dri2_server_generation) {

--- a/src/uxa/intel_driver.c
+++ b/src/uxa/intel_driver.c
@@ -783,11 +783,7 @@ I830HandleUEvents(int fd, void *closure)
 
 static int has_randr(void)
 {
-#if HAS_DIXREGISTERPRIVATEKEY
 	return dixPrivateKeyRegistered(rrPrivKey);
-#else
-	return *rrPrivKey;
-#endif
 }
 
 static void

--- a/src/uxa/intel_uxa.c
+++ b/src/uxa/intel_uxa.c
@@ -1310,11 +1310,7 @@ Bool intel_uxa_init(ScreenPtr screen)
 	if (INTEL_INFO(intel)->gen >= 040 && INTEL_INFO(intel)->gen < 0100)
 		gen4_render_state_init(scrn);
 
-#if HAS_DIXREGISTERPRIVATEKEY
 	if (!dixRegisterPrivateKey(&uxa_pixmap_index, PRIVATE_PIXMAP, 0))
-#else
-	if (!dixRequestPrivate(&uxa_pixmap_index, 0))
-#endif
 		return FALSE;
 
 	intel_limits_init(intel);

--- a/src/uxa/uxa-glyphs.c
+++ b/src/uxa/uxa-glyphs.c
@@ -209,13 +209,8 @@ bail:
 Bool uxa_glyphs_init(ScreenPtr pScreen)
 {
 
-#if HAS_DIXREGISTERPRIVATEKEY
 	if (!dixRegisterPrivateKey(&uxa_glyph_key, PRIVATE_GLYPH, 0))
 		return FALSE;
-#else
-	if (!dixRequestPrivate(&uxa_glyph_key, 0))
-		return FALSE;
-#endif
 
 	/* Skip pixmap creation if we don't intend to use it. */
 	if (uxa_get_screen(pScreen)->force_fallback)

--- a/src/uxa/uxa.c
+++ b/src/uxa/uxa.c
@@ -453,10 +453,9 @@ Bool uxa_driver_init(ScreenPtr screen, uxa_driver_t * uxa_driver)
 			   "non-NULL\n", screen->myNum);
 		return FALSE;
 	}
-#if HAS_DIXREGISTERPRIVATEKEY
+
 	if (!dixRegisterPrivateKey(&uxa_screen_index, PRIVATE_SCREEN, 0))
 	    return FALSE;
-#endif
 	uxa_screen = calloc(1, sizeof(uxa_screen_t));
 
 	if (!uxa_screen) {


### PR DESCRIPTION
It's present since xserver 1.18