### PR TITLE
drop obsolete check for videdrv abi > 10

### DIFF
--- a/src/sna/sna_display.c
+++ b/src/sna/sna_display.c
@@ -2362,9 +2362,7 @@ void sna_copy_fbcon(struct sna *sna)
 
 	kgem_bo_destroy(&sna->kgem, bo);
 
-#if ABI_VIDEODRV_VERSION >= SET_ABI_VERSION(10, 0)
 	to_screen_from_sna(sna)->canDoBGNoneRoot = ok;
-#endif
 }
 
 static bool use_shadow(struct sna *sna, xf86CrtcPtr crtc)

--- a/src/uxa/intel_display.c
+++ b/src/uxa/intel_display.c
@@ -2487,9 +2487,7 @@ void intel_copy_fb(ScrnInfoPtr scrn)
 				0, 0,
 				scrn->virtualX, scrn->virtualY);
 	intel->uxa_driver->done_copy(dst);
-#if ABI_VIDEODRV_VERSION >= SET_ABI_VERSION(10, 0)
 	pScreen->canDoBGNoneRoot = TRUE;
-#endif
 
 cleanup_dst:
 	dixDestroyPixmap(dst, 0);


### PR DESCRIPTION
xserver >= 1.18 has videdrv abi version 20.