### PR TITLE
meson: Automatically detect the default xorg-module-dir.

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -36,5 +36,5 @@ option('async-swap', type : 'boolean', value : false,
        description : 'Enable use of asynchronous swaps (experimental)')
 option('internal-debug', type : 'combo', value : 'no', choices : [ 'no', 'sync', 'memory', 'pixmap', 'full' ],
        description : 'Enable internal debugging')
-option('xorg-module-dir', type : 'string', value : '@libdir@/xorg/modules',
-       description : 'Default xorg module directory')
+option('xorg-module-dir', type: 'string', value: '',
+  description: 'Directory to install the driver in [default=from xorg-server pkgconf]')

--- a/src/meson.build
+++ b/src/meson.build
@@ -134,13 +134,9 @@ if with_valgrind
 endif
 
 xorg_moduledir = get_option('xorg-module-dir')
-moduledir = ''
-foreach dir : xorg_moduledir.split('/')
-  if dir == '@libdir@'
-    dir = get_option('libdir')
-  endif
-  moduledir = join_paths(moduledir, dir)
-endforeach
+if xorg_moduledir == ''
+      xorg_moduledir = xorg.get_variable(pkgconfig: 'moduledir')
+endif
 
 shared_module('intel_drv',
 	      sources : intel_drv_sources,
@@ -152,5 +148,5 @@ shared_module('intel_drv',
 		'-Wno-sign-compare',
 	      ],
 	      name_prefix : '',
-	      install_dir : join_paths(moduledir, 'drivers'),
+	      install_dir : join_paths(xorg_moduledir, 'drivers'),
 	      install : true)


### PR DESCRIPTION
The module directory has changed to a per ABI folder in the xlibre-xserver. Now the default value of `xorg-module-dir` will be detected from the `moduledir` variable in xorg-server.pc.