### PR TITLE
meson.build: Fixed meson errors.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('xf86-video-intel', 'c',
 	  'c_std=gnu99',
 	],
 	license : 'MIT',
-	meson_version : '>=0.50.0')
+	meson_version : '>=0.51.0')
 
 config = configuration_data()
 
@@ -127,10 +127,10 @@ endif
 
 pixman = dependency('pixman-1', version : '>= 0.16.0', required : true)
 
-if pixman.version() >= '0.24.0'
+if pixman.version().version_compare('>=0.24.0')
   config.set('HAS_PIXMAN_TRIANGLES', 1)
 endif
-if pixman.version() >= '0.27.1'
+if pixman.version().version_compare('>=0.27.1')
   config.set('HAS_PIXMAN_GLYPHS', 1)
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,7 +23,7 @@ if with_dri2
 
   dri = dependency('dri', required : false)
   if dri.found()
-    dridriverdir = dri.get_pkgconfig_variable('dridriverdir')
+    dridriverdir = dri.get_variable(pkgconfig:'dridriverdir')
   else
     dridriverdir = join_paths(get_option('libdir'), 'dri')
   endif


### PR DESCRIPTION
Replaced the deprecated get_pkgconfig_variable with get_variable.

Moved the meson_version to 0.51.0 for get_variable.

Replaced the incorrect version comparison with the correct .version_compare method.