### PR TITLE
configure.ac: drop HAVE_X11 conditional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,13 +26,9 @@ DISTCHECK_CONFIGURE_FLAGS = --with-xorg-module-dir='$${libdir}/xorg/modules'
 #ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = man libobj xvmc src tools
+SUBDIRS = man libobj xvmc src tools test benchmarks
 
 MAINTAINERCLEANFILES = ChangeLog INSTALL
-
-if HAVE_X11
-SUBDIRS += test benchmarks
-endif
 
 .PHONY: ChangeLog INSTALL
 

--- a/configure.ac
+++ b/configure.ac
@@ -182,9 +182,8 @@ if test "x$UDEV" != "xno"; then
         fi
 fi
 
-PKG_CHECK_MODULES(X11, [x11 x11-xcb xcb-dri2 xcomposite xdamage xrender xrandr xext xfixes cairo cairo-xlib-xrender pixman-1 libpng], [x11="yes"], [x11="no"])
-AM_CONDITIONAL(HAVE_X11, test "x$x11" = "xyes")
-echo X11_CLFAGS="$X11_CLFAGS" X11_LIBS="$X11_LIBS"
+PKG_CHECK_MODULES(X11,
+                  [x11 x11-xcb xcb-dri2 xcomposite xdamage xrender xrandr xext xfixes cairo cairo-xlib-xrender pixman-1 libpng])
 
 cpuid="yes"
 AC_TRY_LINK([


### PR DESCRIPTION
trying to build an Xserver driver w/o having X11 installed doesn't make much sense at all.