### PR TITLE
sna: sna_accel: fix type of sigjmp

### DIFF
--- a/src/sna/sna_accel.c
+++ b/src/sna/sna_accel.c
@@ -381,7 +381,7 @@ static void assert_pixmap_damage(PixmapPtr p)
 #endif
 #endif
 
-jmp_buf sigjmp[4];
+sigjmp_buf sigjmp[4];
 volatile sig_atomic_t sigtrap;
 
 static int sigtrap_handler(int sig)


### PR DESCRIPTION
Needs to be sigjmp_buf instead of jmp_buf.