### PR TITLE
sna: drop duplicate definition of FOURCC_RGB565

### DIFF
--- a/src/sna/sna_video.h
+++ b/src/sna/sna_video.h
@@ -36,7 +36,6 @@ THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 
 #define FOURCC_XVMC (('C' << 24) + ('M' << 16) + ('V' << 8) + 'X')
-#define FOURCC_RGB565 ((16 << 24) + ('B' << 16) + ('G' << 8) + 'R')
 #define FOURCC_RGB888 ((24 << 24) + ('B' << 16) + ('G' << 8) + 'R')
 #ifndef FOURCC_NV12
 #define FOURCC_NV12 (('2' << 24) + ('1' << 16) + ('V' << 8) + 'N')


### PR DESCRIPTION
> sna_video.h:39: warning: "FOURCC_RGB565" redefined
>    39 | #define FOURCC_RGB565 ((16 << 24) + ('B' << 16) + ('G' << 8) + 'R')
>       |
> In file included from sna_video.h:32:
> /usr/include/xorg/fourcc.h:199: note: this is the location of the previous definition
>   199 | #define FOURCC_RGB565 0x36314752
>       |