### PR TITLE
meson.build: fix missing config.h include

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -136,6 +136,7 @@ endif
 shared_module('intel_drv',
 	      sources : intel_drv_sources,
 	      dependencies : intel_drv_deps,
+	      include_directories: inc,
 	      link_with : intel_drv_libs,
 	      c_args : [
 		'-DMAJOR_IN_SYSMACROS',

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -18,6 +18,7 @@ if with_tools
 	     c_args : [
 	       '-Wno-unused-parameter',
 	     ],
+	     include_directories: inc,
 	     install : true)
 
   configure_file(input : 'intel-virtual-output.man',
@@ -54,6 +55,7 @@ if with_tools
 	     c_args : [
 	       '-Wno-unused-parameter',
 	     ],
+	     include_directories: inc,
 	     install : false)
 endif
 
@@ -81,6 +83,7 @@ if with_backlight_helper
 	     c_args : [
 	       '-DMAJOR_IN_SYSMACROS',
 	     ],
+	     include_directories: inc,
 	     install : true)
 
   polkit_config = configuration_data()


### PR DESCRIPTION
Add include_directory arguments to the meson.build files in src and
tools so the config.h include can be found.

Fixes: #57
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
