### PR TITLE
(master) sna_display: drop unused variable in sna_crtc_set_mode_major()

### DIFF
--- a/src/sna/sna_display.c
+++ b/src/sna/sna_display.c
@@ -3118,7 +3118,6 @@ static Bool
 sna_crtc_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
 			Rotation rotation, int x, int y)
 {
-	struct sna *sna = to_sna(crtc->scrn);
 	struct sna_crtc *sna_crtc = to_sna_crtc(crtc);
 	struct drm_mode_modeinfo saved_kmode;
 	char outputs[256];


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
