### PR TITLE
(master) sna: sna_accel: fix retval of sna_copy_plane()

### DIFF
--- a/src/sna/sna_accel.c
+++ b/src/sna/sna_accel.c
@@ -8840,7 +8840,7 @@ sna_copy_plane(DrawablePtr src, DrawablePtr dst, GCPtr gc,
 		}
 
 		if (!kgem_bo_can_blt(&sna->kgem, arg.bo))
-			return false;
+			return NULL;
 
 		RegionUninit(&region);
 		return sna_do_copy(src, dst, gc,


### PR DESCRIPTION
We need to return NULL instead of false here.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
