### PR TITLE
xf86-video-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,8 @@ AC_CONFIG_AUX_DIR(.)
 # Initialize Automake
 AM_INIT_AUTOMAKE([foreign dist-bzip2])
 
+CFLAGS="-std=gnu99 $CFLAGS"
+
 # Require X.Org macros 1.8 or later for MAN_SUBSTS set by XORG_MANPAGE_SECTIONS
 m4_ifndef([XORG_MACROS_VERSION],
           [m4_fatal([must install xorg-macros 1.8 or later before running autoconf/autogen.

--- a/src/sna/sna_display.c
+++ b/src/sna/sna_display.c
@@ -3133,8 +3133,11 @@ sna_crtc_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
 		   outputs_for_crtc(crtc, outputs, sizeof(outputs)), __sna_crtc_index(sna_crtc),
 		   x, y, rotation_to_str(rotation), reflection_to_str(rotation));
 
+#ifndef NDEBUG
+	struct sna *sna = to_sna(crtc->scrn);
 	assert(mode->HDisplay <= sna->mode.max_crtc_width &&
 	       mode->VDisplay <= sna->mode.max_crtc_height);
+#endif
 
 #if HAS_GAMMA
 	sna_crtc_gamma_set(crtc,

--- a/src/sna/sna_driver.c
+++ b/src/sna/sna_driver.c
@@ -1254,12 +1254,12 @@ static Bool sna_pm_event(ScrnInfoPtr scrn, pmEvent event, Bool undo)
 	case XF86_APM_SYS_STANDBY:
 	case XF86_APM_USER_STANDBY:
 		if (!undo && !sna->suspended) {
-			scrn->LeaveVT(NULL);
+			scrn->LeaveVT(scrn);
 			sna->suspended = TRUE;
 			sleep(SUSPEND_SLEEP);
 		} else if (undo && sna->suspended) {
 			sleep(RESUME_SLEEP);
-			scrn->EnterVT(NULL);
+			scrn->EnterVT(scrn);
 			sna->suspended = FALSE;
 		}
 		break;
@@ -1268,7 +1268,7 @@ static Bool sna_pm_event(ScrnInfoPtr scrn, pmEvent event, Bool undo)
 	case XF86_APM_CRITICAL_RESUME:
 		if (sna->suspended) {
 			sleep(RESUME_SLEEP);
-			scrn->EnterVT(NULL);
+			scrn->EnterVT(scrn);
 			sna->suspended = FALSE;
 			/*
 			 * Turn the screen saver off when resuming.  This seems to be

--- a/src/uxa/intel_driver.c
+++ b/src/uxa/intel_driver.c
@@ -1032,7 +1032,7 @@ I830ScreenInit(ScreenPtr screen, int argc, char **argv)
 	 * later memory should be bound when allocating, e.g rotate_mem */
 	scrn->vtSema = TRUE;
 
-	return I830EnterVT(NULL);
+	return I830EnterVT(scrn);
 }
 
 static void i830AdjustFrame(ScrnInfoPtr scrn, int x, int y)
@@ -1126,7 +1126,7 @@ static Bool I830CloseScreen(ScreenPtr screen)
 	}
 
 	if (scrn->vtSema == TRUE) {
-		I830LeaveVT(NULL);
+		I830LeaveVT(scrn);
 	}
 
 	intel_batch_teardown(scrn);
@@ -1194,12 +1194,12 @@ static Bool I830PMEvent(ScrnInfoPtr scrn, pmEvent event, Bool undo)
 	case XF86_APM_SYS_STANDBY:
 	case XF86_APM_USER_STANDBY:
 		if (!undo && !intel->suspended) {
-			scrn->LeaveVT(NULL);
+			scrn->LeaveVT(scrn);
 			intel->suspended = TRUE;
 			sleep(SUSPEND_SLEEP);
 		} else if (undo && intel->suspended) {
 			sleep(RESUME_SLEEP);
-			scrn->EnterVT(NULL);
+			scrn->EnterVT(scrn);
 			intel->suspended = FALSE;
 		}
 		break;
@@ -1208,7 +1208,7 @@ static Bool I830PMEvent(ScrnInfoPtr scrn, pmEvent event, Bool undo)
 	case XF86_APM_CRITICAL_RESUME:
 		if (intel->suspended) {
 			sleep(RESUME_SLEEP);
-			scrn->EnterVT(NULL);
+			scrn->EnterVT(scrn);
 			intel->suspended = FALSE;
 			/*
 			 * Turn the screen saver off when resuming.  This seems to be


### PR DESCRIPTION
There are fixes for recent (not that recent) issues.

I think it should at least fix:
https://github.com/X11Libre/xf86-video-intel/issues/65
https://github.com/X11Libre/xf86-video-intel/issues/64
https://github.com/X11Libre/xf86-video-intel/issues/51

These fixes includes:
* align c version with configure.ac and meson.build
* revert recent commit - we should check debug and non debug build
* fix oversight on c594e6cd7d7092c343ae8858f324298ce252c4c8  

